### PR TITLE
Fix lightline#ale#linted regression from formatting

### DIFF
--- a/autoload/lightline/ale.vim
+++ b/autoload/lightline/ale.vim
@@ -43,7 +43,5 @@ endfunction
 " Helper functions
 
 function! lightline#ale#linted() abort
-  return get(g:, 'ale_enabled', 0) == 1 \
-      && getbufvar(bufnr(''), 'ale_linted', 0) > 0 \
-      && ale#engine#IsCheckingBuffer(bufnr('')) == 0
+  return get(g:, 'ale_enabled', 0) == 1 && getbufvar(bufnr(''), 'ale_linted', 0) > 0 && ale#engine#IsCheckingBuffer(bufnr('')) == 0
 endfunction

--- a/autoload/lightline/ale.vim
+++ b/autoload/lightline/ale.vim
@@ -43,5 +43,7 @@ endfunction
 " Helper functions
 
 function! lightline#ale#linted() abort
-  return get(g:, 'ale_enabled', 0) == 1 && getbufvar(bufnr(''), 'ale_linted', 0) > 0 && ale#engine#IsCheckingBuffer(bufnr('')) == 0
+  return get(g:, 'ale_enabled', 0) == 1
+    \ && getbufvar(bufnr(''), 'ale_linted', 0) > 0
+    \ && ale#engine#IsCheckingBuffer(bufnr('')) == 0
 endfunction

--- a/plugin/lightline/ale.vim
+++ b/plugin/lightline/ale.vim
@@ -2,4 +2,5 @@ augroup lightline#ale
   autocmd!
   autocmd User ALEJobStarted call lightline#update()
   autocmd User ALELintPost call lightline#update()
+  autocmd User ALEFixPost call lightline#update()
 augroup END


### PR DESCRIPTION
 - A regression was introduced when formatting the multiline conditional of `lightline#ale#linted`.
   - @jguyon fixed the multiline formatting
 - Also call `lightline#update()` when new `ALEFixPost` event is called. 