### PR TITLE
Don't count info messages as warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ let g:lightline.component_expand = {
 
 ```viml
 let g:lightline.component_type = {
-      \     'linter_checking': 'left',
-      \     'linter_infos': 'normal',
+      \     'linter_checking': 'right',
+      \     'linter_infos': 'right',
       \     'linter_warnings': 'warning',
       \     'linter_errors': 'error',
-      \     'linter_ok': 'left',
+      \     'linter_ok': 'right',
       \ }
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ let g:lightline = {}
 
 let g:lightline.component_expand = {
       \  'linter_checking': 'lightline#ale#checking',
+      \  'linter_infos': 'lightline#ale#infos',
       \  'linter_warnings': 'lightline#ale#warnings',
       \  'linter_errors': 'lightline#ale#errors',
       \  'linter_ok': 'lightline#ale#ok',
@@ -41,6 +42,7 @@ let g:lightline.component_expand = {
 ```viml
 let g:lightline.component_type = {
       \     'linter_checking': 'left',
+      \     'linter_infos': 'normal',
       \     'linter_warnings': 'warning',
       \     'linter_errors': 'error',
       \     'linter_ok': 'left',
@@ -50,7 +52,7 @@ let g:lightline.component_type = {
 3. Add the components to the lightline, for example to the right side:
 
 ```viml
-let g:lightline.active = { 'right': [[ 'linter_checking', 'linter_errors', 'linter_warnings', 'linter_ok' ]] }
+let g:lightline.active = { 'right': [[ 'linter_checking', 'linter_errors', 'linter_warnings', 'linter_infos', 'linter_ok' ]] }
 ```
 
 ## Configuration
@@ -58,6 +60,10 @@ let g:lightline.active = { 'right': [[ 'linter_checking', 'linter_errors', 'lint
 ##### `g:lightline#ale#indicator_checking`
 
 The indicator to use when ALE is in progress. Default is `Linting...`.
+
+##### `g:lightline#ale#indicator_infos`
+
+The indicator to use when there are infos. Default is `I:`.
 
 ##### `g:lightline#ale#indicator_warnings`
 
@@ -78,6 +84,7 @@ If you would like to replace the default indicators with symbols like on the scr
 The following icons from the Font Awesome font are used in the screenshot:
 
 * Checking: [f110](https://fontawesome.com/icons/spinner)
+* Infos: [f129](https://fontawesome.com/icons/info)
 * Warnings: [f071](https://fontawesome.com/icons/exclamation-triangle)
 * Errors: [f05e](https://fontawesome.com/icons/ban)
 * OK: [f00c](https://fontawesome.com/icons/check) (although I prefer to disable this component)
@@ -93,6 +100,7 @@ Here's the configuration snippet used in the screenshot:
 
 ```viml
 let g:lightline#ale#indicator_checking = "\uf110"
+let g:lightline#ale#indicator_infos = "\uf129"
 let g:lightline#ale#indicator_warnings = "\uf071"
 let g:lightline#ale#indicator_errors = "\uf05e"
 let g:lightline#ale#indicator_ok = "\uf00c"

--- a/autoload/lightline/ale.vim
+++ b/autoload/lightline/ale.vim
@@ -1,3 +1,4 @@
+let s:indicator_infos = get(g:, 'lightline#ale#indicator_infos', 'I: ')
 let s:indicator_warnings = get(g:, 'lightline#ale#indicator_warnings', 'W: ')
 let s:indicator_errors = get(g:, 'lightline#ale#indicator_errors', 'E: ')
 let s:indicator_ok = get(g:, 'lightline#ale#indicator_ok', 'OK')
@@ -7,14 +8,21 @@ let s:indicator_checking = get(g:, 'lightline#ale#indicator_checking', 'Linting.
 """"""""""""""""""""""
 " Lightline components
 
+function! lightline#ale#infos() abort
+  if !lightline#ale#linted()
+    return ''
+  endif
+  let l:counts = ale#statusline#Count(bufnr(''))
+  return l:counts.info == 0 ? '' : printf(s:indicator_infos . '%d', l:counts.info)
+endfunction
+
 function! lightline#ale#warnings() abort
   if !lightline#ale#linted()
     return ''
   endif
   let l:counts = ale#statusline#Count(bufnr(''))
-  let l:all_errors = l:counts.error + l:counts.style_error
-  let l:all_non_errors = l:counts.total - l:all_errors - l:counts.info
-  return l:all_non_errors == 0 ? '' : printf(s:indicator_warnings . '%d', all_non_errors)
+  let l:all_warnings = l:counts.warning + l:counts.style_warning
+  return l:all_warnings == 0 ? '' : printf(s:indicator_warnings . '%d', all_warnings)
 endfunction
 
 function! lightline#ale#errors() abort

--- a/autoload/lightline/ale.vim
+++ b/autoload/lightline/ale.vim
@@ -13,7 +13,7 @@ function! lightline#ale#warnings() abort
   endif
   let l:counts = ale#statusline#Count(bufnr(''))
   let l:all_errors = l:counts.error + l:counts.style_error
-  let l:all_non_errors = l:counts.total - l:all_errors
+  let l:all_non_errors = l:counts.total - l:all_errors - l:counts.info
   return l:all_non_errors == 0 ? '' : printf(s:indicator_warnings . '%d', all_non_errors)
 endfunction
 


### PR DESCRIPTION
ALE differentiates between info, warning, and error.
Infos should not be listed as warnings.