### PR TITLE
Add full example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ let g:lightline.component_type = {
 let g:lightline.active = { 'right': [[ 'linter_checking', 'linter_errors', 'linter_warnings', 'linter_infos', 'linter_ok' ]] }
 ```
 
+      3.1. Lineinfo, fileformat, etc. have to be added additionaly. Final example:
+
+```viml
+let g:lightline.active = {
+            \ 'right': [ [ 'linter_checking', 'linter_errors', 'linter_warnings', 'linter_infos', 'linter_ok' ],
+            \            [ 'lineinfo' ],
+	    \            [ 'percent' ],
+	    \            [ 'fileformat', 'fileencoding', 'filetype'] ]}
+
+```
+            
 ## Configuration
 
 ##### `g:lightline#ale#indicator_checking`


### PR DESCRIPTION
I was googling for 20 minutes, on why my lineinfo and other stuff is gone, as soon as I add code from README... 

Specifying this additional in README here, would help others, who are just starting with lightline, maybe, hopefully.